### PR TITLE
Logs table needs t.timestamps

### DIFF
--- a/db/migrate/20130227192935_setup_projects_tasks_logs.rb
+++ b/db/migrate/20130227192935_setup_projects_tasks_logs.rb
@@ -16,6 +16,7 @@ class SetupProjectsTasksLogs < ActiveRecord::Migration
       t.references :task, index: true
       t.timestamp :start
       t.timestamp :stop
+      t.timestamps
     end
 
   end


### PR DESCRIPTION
The _logs_ table needs a t.timestamps declaration during its creation.  If the included change is not in place then the following error occurs: http://www.screencast.com/t/5yU4cLOjVbwB
